### PR TITLE
あいこんくらぶは過去の作品になりました

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,10 @@
           </ul>
         </div>
       </section>
+    </article>
+    <div class="wave wave-dotted"></div>
+    <article class="article-screen article-screen-pastwork">
+      <h2>過去の作品たち</h2>
       <section class="working-section">
         <h3 class="working-section__caption">あいこんくらぶ</h3>
         <div class="working-section__service-logo">
@@ -153,6 +157,7 @@
           <p><a href="https://iconclub.jp" target="_blank">https://iconclub.jp</a></p>
         </div>
         <div class="working-section__details">
+          <p>(公開期間: 2015/06 ～ 2020/02)</p>
           <p>ブラウザでドット絵を描いて公開できるサービスです</p>
           <ul>
             <li>お手持ちのドット絵をアップロードして公開できます（おおきさ256px四方まで）</li>
@@ -168,10 +173,6 @@
           </ul>
         </div>
       </section>
-    </article>
-    <div class="wave wave-dotted"></div>
-    <article class="article-screen article-screen-pastwork">
-      <h2>過去の作品たち</h2>
       <section class="working-section">
         <h3 class="working-section__caption">以前のがらくたツールボックスのサイト</h3>
         <div class="working-section__service-logo">


### PR DESCRIPTION
2020/3/1 に公開終了するので、こちらのほうでも過去の作品扱いにします。