### PR TITLE
gatsby-plugin-react-helmetを追加する

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,8 +5,7 @@
  */
 
 module.exports = {
-  /* Your site config here */
-  plugins: [],
+  plugins: ['gatsby-plugin-react-helmet'],
   siteMetadata: {
     title: 'がらくたツールボックス',
     siteName: 'がらくたツールボックス',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "0BSD",
       "dependencies": {
         "gatsby": "^3.4.0",
+        "gatsby-plugin-react-helmet": "^4.4.0",
         "react-helmet": "^6.1.0"
       },
       "devDependencies": {
@@ -8842,6 +8843,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gatsby-plugin-react-helmet": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-4.4.0.tgz",
+      "integrity": "sha512-LVWGgMVQbOrBIHPz8ghjmglDbFM5X/IdX4g8WT7o4IknktRLlHY8ETkn3DQzuB7/3PFgAbFpEXerCXb7XpwQdA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^3.0.0-next.0",
+        "react-helmet": "^5.1.3 || ^6.0.0"
       }
     },
     "node_modules/gatsby-plugin-typescript": {
@@ -27600,6 +27616,14 @@
             "slash": "^3.0.0"
           }
         }
+      }
+    },
+    "gatsby-plugin-react-helmet": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-4.4.0.tgz",
+      "integrity": "sha512-LVWGgMVQbOrBIHPz8ghjmglDbFM5X/IdX4g8WT7o4IknktRLlHY8ETkn3DQzuB7/3PFgAbFpEXerCXb7XpwQdA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "gatsby-plugin-typescript": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "gatsby": "^3.4.0",
+    "gatsby-plugin-react-helmet": "^4.4.0",
     "react-helmet": "^6.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/ を入れることで、react-helmet で描画したOGPメタタグが静的にコンテンツ上に現れるようにして、SNSなどで共有したときにそれっぽいプレビューが表示されるようにします。